### PR TITLE
Fix warning C4477.

### DIFF
--- a/build/perflib.c
+++ b/build/perflib.c
@@ -169,7 +169,7 @@ static void mark_function(lua_State *L, lua_State *dL) {
 		
 		lua_pushvalue(L, -1);
 		lua_getinfo(L, ">S", &ar);
-		snprintf(used_in, sizeof(used_in) - 1, "%.*s:%d~%d", sizeof(ar.short_src)/sizeof(ar.short_src[0]), ar.short_src, ar.linedefined, ar.lastlinedefined);
+		snprintf(used_in, sizeof(used_in) - 1, "%.*s:%d~%d", (int)(sizeof(ar.short_src)/sizeof(ar.short_src[0])), ar.short_src, ar.linedefined, ar.lastlinedefined);
 		used_in[sizeof(used_in) - 1] = 0;
 		
 		for (i=1;;i++) {


### PR DESCRIPTION
warning C4477: 'snprintf' : format string '%.*s' requires an argument of type 'int', but variadic argument 1 has type 'unsigned __int64'